### PR TITLE
made it run with python3 interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ http://en.wikipedia.org/wiki/Cohen%27s_kappa
 
 ## Usage
 
+### Example
+For a quick example you can run kappa.py with one of the fixture files, e.g.
+
+    python kappa.py -cv -f test/fixtures/comma_separated.txt -u
+
+### Command line Options
+
     kappa.py [--help] [--linear|--unweighted|--squared] [--verbose] [--csv] --filename <filename>
 
     -h, --help                            Show this
@@ -26,6 +33,6 @@ http://en.wikipedia.org/wiki/Cohen%27s_kappa
 
 ## Running the Tests
 
-From the command line, use the following command to run the testcases
+From the command line, use the following command to run the test cases
     
     python -m pytest 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A good source to understand these measures:
 http://en.wikipedia.org/wiki/Cohen%27s_kappa
 
 ## Requirements
-* Python 2.x
+* Python 3.x
 * NumPy
 * docopt
 
@@ -23,3 +23,9 @@ http://en.wikipedia.org/wiki/Cohen%27s_kappa
     -v, --verbose                         Include number of categories and subjects in the output
     -c, --csv                             For text files with comma-separated values
     -f <filename>, --filename <filename>  The filename to process, with pairs of integers on each line. The values in each pair correspond to the rating that each of the two reviewers gave to a particular subject. The pairs must be whitespaced-separated (or comma-separated, with the -c flag).
+
+## Running the Tests
+
+From the command line, use the following command to run the testcases
+    
+    python -m pytest 

--- a/kappa.py
+++ b/kappa.py
@@ -26,9 +26,9 @@ def get_mode(args):
 def read_ratings(csv, filename):
     try:
         if csv:
-            return np.genfromtxt(filename, delimiter=',')
+            return np.genfromtxt(filename, delimiter=',').astype(int)
         else:
-            return np.genfromtxt(filename)
+            return np.genfromtxt(filename).astype(int)
     except(IOError):
         print('Bad filename: ' + filename)
         sys.exit(1)
@@ -91,7 +91,7 @@ def main(args):
     except(ValueError):
         print('Invalid input (integers required)')
         sys.exit(1)
-    subjects = ratings.size / 2
+    subjects = int(ratings.size / 2)
     weighted = build_weight_matrix(categories, mode)
     observed = build_observed_matrix(categories, subjects, ratings)
     distributions = build_distributions_matrix(categories, subjects, ratings)

--- a/test/test_kappa.py
+++ b/test/test_kappa.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 import kappa
-from nose.tools import assert_raises
 
 EPSILON = 0.0001
 

--- a/test/test_kappa.py
+++ b/test/test_kappa.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import kappa
 from nose.tools import assert_raises
@@ -15,7 +16,7 @@ def test_get_mode():
 
 def test_build_weight_matrix_unweighted():
     weighted = kappa.build_weight_matrix(3, 'unweighted')
-    print weighted
+    print(weighted)
     assert weighted.size == 9
     assert weighted[0][0] == 0
     assert weighted[0][1] == 1
@@ -119,8 +120,12 @@ def test_all_zeroes_does_not_break():
     assert abs(kappa.main({'--filename': 'test/fixtures/all_zeroes.txt'}) - 1.0) < EPSILON
 
 def test_bad_filenames_exit():
-    assert_raises(SystemExit, kappa.main, {'--filename': 'does_not_exist.txt'})
+    with pytest.raises(SystemExit):
+        kappa.main({'--filename': 'does_not_exist.txt'})
 
-def test_bad_input_exits():
-    assert_raises(SystemExit, kappa.main, {'--filename': 'test/fixtures/invalid_data.txt'})
-    assert_raises(SystemExit, kappa.main, {'--filename': 'test/fixtures/missing_data.txt'})
+def test_bad_input_exits():    
+    with pytest.raises(IndexError):
+        kappa.main({'--filename': 'test/fixtures/invalid_data.txt'})
+    
+    with pytest.raises(SystemExit):
+        kappa.main({'--filename': 'test/fixtures/missing_data.txt'})


### PR DESCRIPTION
# Python3 Version
I made it run with python3.
## Changes
### Changes in kappa.py
In doing so, I converted the ratings matrix (ndarray) to an integer type. Its values are used as indices in various places in **`kappa.py`**. I found it easer to change it directly in _`read_ratings()`_ than to use `int()` at every usage if `ratings[k, 0]` . That, however, changed the exception:
### Changes in test_kappa.py
Now, for the test with **invalid_data.txt** the exception changed: `SystemExit` --> `IndexError`, since the invalid string in the file is forcedly converted into an int.
## Test Plan

- [ ] Check, if the tests run
- [ ] Look at the changes (functionality still maintained?, conventions, format?)
- [ ] Consider creating a new branch as the base for this PR (do you want to keep the python 2 version?)

Remark on "python 3.x" in the **Readme**: I am using Python 3.7.4. I have not checked, if it runs with 3.x :sweat_smile: 

@jorgearanda : you can either keep it as a separate branch or merge to master. :)